### PR TITLE
Upgrade @aantron/repromise to reason-promise

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -11,7 +11,7 @@
   },
   "suffix": ".bs.js",
   "bs-dependencies": [
-    "@aantron/repromise"
+    "reason-promise"
   ],
   "warnings": {
     "error" : "+101"

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "typescript": "^3.7.2"
   },
   "devDependencies": {
-    "@aantron/repromise": "^0.6.1",
     "bs-platform": "^7.0.1",
-    "bsb-js": "^1.1.7"
+    "bsb-js": "^1.1.7",
+    "reason-promise": "^1.0.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,11 +2,6 @@
 # yarn lockfile v1
 
 
-"@aantron/repromise@^0.6.1":
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/@aantron/repromise/-/repromise-0.6.1.tgz#5ad99cba57f5a4a88783b833ef2a3d2d9dfdba2f"
-  integrity sha512-dHWAWTlpPQCZcN9sCOzljOcMCD7ipQgLE1NOA3CszUxS3FKCl7muave235AX/waV5V6KqRFscg0iQVz2phZTNA==
-
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.5.5":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.5.5.tgz#bc0782f6d69f7b7d49531219699b988f669a8f9d"
@@ -4395,6 +4390,11 @@ readdirp@^2.2.1:
     graceful-fs "^4.1.11"
     micromatch "^3.1.10"
     readable-stream "^2.0.2"
+
+reason-promise@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/reason-promise/-/reason-promise-1.0.2.tgz#22b9bb4097ce511190182b948aef11427d5b8b86"
+  integrity sha512-j8DWV+71wNEKQmyW6zBOowIZq1Qec5CDWyLI37BvgOmAZgRFGFQ1MaJnbhqDe3JsYmaGyqdNMmpCJLl9EDbDAg==
 
 regenerate-unicode-properties@^8.1.0:
   version "8.1.0"


### PR DESCRIPTION
Repromise became [**reason-promise**](https://github.com/aantron/promise) in 1.0.0. The API was renamed (e.g., `Repromise.wait` is now `Promise.get`), rearranged to prefer `->` instead of `|>`, and helpers were added for `Result` and `Option`, as well as some miscellaneous ones. The bundle size was reduced to 1K. See the [changelog](https://github.com/aantron/promise/releases/tag/1.0.0) here; there are also two subsequent bugfix releases.